### PR TITLE
Revert "Bump djangorestframework-simplejwt from 5.4.0 to 5.5.0 in /backend"

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ django-debug-toolbar==5.0.1
 django-filter==25.1
 django-templated-mail==1.1.1
 djangorestframework==3.15.2
-djangorestframework-simplejwt==5.5.0
+djangorestframework-simplejwt==5.4.0
 djoser==2.3.1
 drf-extra-fields==3.7.0
 filetype==1.2.0


### PR DESCRIPTION
Reverts kopf8/foodgram#75

## Summary by Sourcery

Bug Fixes:
- Downgrade djangorestframework-simplejwt to resolve potential compatibility or stability issues introduced by version 5.5.0